### PR TITLE
Remove unsupported assets

### DIFF
--- a/cryptopay/enums/asset.py
+++ b/cryptopay/enums/asset.py
@@ -6,13 +6,6 @@ class Asset(str, Enum):
 
     USDT = "USDT"
     TON = "TON"
-    SOL = "SOL"
-    GRAM = "GRAM"
-    NOT = "NOT"
-    HMSTR = "HMSTR"
-    CATI = "CATI"
-    MY = "MY"
-    DOGS = "DOGS"
     BTC = "BTC"
     LTC = "LTC"
     ETH = "ETH"


### PR DESCRIPTION
This pull request refines the `Asset` enum in the `cryptopay/enums/asset.py` file by removing several unused asset types. This contributes to the overall codebase simplification and ensures that only relevant asset types are maintained in the enum.

### Changes Made:
- **Removed Unused Asset Types**:  
  Removed the following unused asset types from the `Asset` enum:
  - SOL
  - GRAM
  - NOT
  - HMSTR
  - CATI
  - MY
  - DOGS
  
  These asset types were no longer being used and their removal will help reduce clutter and improve maintainability.

- **File Affected**:  
  - `cryptopay/enums/asset.py`

### Context:
- An API error `[400] /createInvoice: UNSUPPORTED_ACCEPTED_ASSET` was raised when trying to use unsupported asset types. The allowed assets for the `createInvoice` API now include only the following:
  - USDT, TON, BTC, DOGE, LTC, ETH, BNB, TRX, USDC, JET, SEND.