### PR TITLE
fix: thread safety improvements for free-threaded Python

### DIFF
--- a/aiosend/_events/observer.py
+++ b/aiosend/_events/observer.py
@@ -39,7 +39,7 @@ class EventObserver:
         **kwargs: object,
     ) -> bool:
         """Trigger event observer."""
-        for handler in self.handlers:
+        for handler in list(self.handlers):
             result, data = await handler.check(event)
             if result:
                 await handler.call(event, data | kwargs)

--- a/aiosend/_events/router.py
+++ b/aiosend/_events/router.py
@@ -58,7 +58,7 @@ class BaseRouter:
         if observer is not None:
             is_handled = await observer.trigger(event, **kwargs)
 
-        for router in self.sub_routers:
+        for router in list(self.sub_routers):
             is_handled = await router.propagate_event(
                 event,
                 event_type,

--- a/aiosend/_utils/sync.py
+++ b/aiosend/_utils/sync.py
@@ -23,13 +23,10 @@ def async_to_sync(obj: object, name: str) -> None:
     ) -> object:
         coro: Coroutine = method(*args, **kwargs)
         try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-        if loop.is_running():
+            asyncio.get_running_loop()
             return coro
-        return loop.run_until_complete(coro)
+        except RuntimeError:
+            return asyncio.run(coro)
 
     setattr(obj, name, sync_wrapper)
 

--- a/aiosend/client/session/aiohttp.py
+++ b/aiosend/client/session/aiohttp.py
@@ -26,7 +26,6 @@ class AiohttpSession(BaseSession):
 
     def __init__(self, network: "Network", timeout: float = 300) -> None:
         super().__init__(network, timeout)
-        self._session: ClientSession | None = None
 
     async def request(
         self,
@@ -36,13 +35,12 @@ class AiohttpSession(BaseSession):
     ) -> "_CryptoPayType":
         """Make http request."""
         ssl_context = ssl.create_default_context(cafile=certifi.where())
-        self._session = ClientSession(
+        async with ClientSession(
             timeout=ClientTimeout(self.timeout),
             connector=TCPConnector(
                 ssl_context=ssl_context,
             ),
-        )
-        async with self._session as session:
+        ) as session:
             try:
                 resp = await session.post(
                     url=self.network.url(method),

--- a/aiosend/polling/check.py
+++ b/aiosend/polling/check.py
@@ -1,3 +1,4 @@
+import threading
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,7 @@ class CheckPollingManager(BasePollingManager, PollingRouter, ABC):
     def __init__(self) -> None:
         super().__init__()
         self._check_tasks: dict[int, PollingTask[Check]] = {}
+        self._check_lock = threading.Lock()
 
     @abstractmethod
     async def get_checks(
@@ -31,17 +33,22 @@ class CheckPollingManager(BasePollingManager, PollingRouter, ABC):
         """getchecks method."""
 
     def _poll_check(self, check: "Check", **kwargs: object) -> None:
-        self._check_tasks[check.check_id] = PollingTask(
-            check,
-            self._timeout,
-            kwargs,
-        )
+        with self._check_lock:
+            self._check_tasks[check.check_id] = PollingTask(
+                check,
+                self._timeout,
+                kwargs,
+            )
 
     async def _handle_check(self, check: "Check") -> None:
-        task = self._check_tasks[check.check_id]
-        task.timeout -= self._delay
-        if check.status == CheckStatus.ACTIVATED or task.timeout <= 0:
-            del self._check_tasks[check.check_id]
+        with self._check_lock:
+            task = self._check_tasks.get(check.check_id)
+            if task is None:
+                return
+            task.timeout -= self._delay
+            if check.status == CheckStatus.ACTIVATED or task.timeout <= 0:
+                del self._check_tasks[check.check_id]
+
         if task.timeout <= 0:
             if await self.propagate_event(
                 check,

--- a/aiosend/polling/invoice.py
+++ b/aiosend/polling/invoice.py
@@ -1,3 +1,4 @@
+import threading
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,7 @@ class InvoicePollingManager(BasePollingManager, PollingRouter, ABC):
     def __init__(self) -> None:
         super().__init__()
         self._invoice_tasks: dict[int, PollingTask[Invoice]] = {}
+        self._invoice_lock = threading.Lock()
 
     @abstractmethod
     async def get_invoices(  # noqa: PLR0913
@@ -39,23 +41,28 @@ class InvoicePollingManager(BasePollingManager, PollingRouter, ABC):
         invoice: "Invoice",
         **kwargs: object,
     ) -> None:
-        self._invoice_tasks[invoice.invoice_id] = PollingTask(
-            invoice,
-            self._timeout,
-            kwargs,
-        )
+        with self._invoice_lock:
+            self._invoice_tasks[invoice.invoice_id] = PollingTask(
+                invoice,
+                self._timeout,
+                kwargs,
+            )
 
     async def _handle_invoice(
         self,
         invoice: "Invoice",
     ) -> None:
-        task = self._invoice_tasks[invoice.invoice_id]
-        task.timeout -= self._delay
-        if (
-            invoice.status in (InvoiceStatus.PAID, InvoiceStatus.EXPIRED)
-            or task.timeout <= 0
-        ):
-            del self._invoice_tasks[invoice.invoice_id]
+        with self._invoice_lock:
+            task = self._invoice_tasks.get(invoice.invoice_id)
+            if task is None:
+                return
+            task.timeout -= self._delay
+            if (
+                invoice.status in (InvoiceStatus.PAID, InvoiceStatus.EXPIRED)
+                or task.timeout <= 0
+            ):
+                del self._invoice_tasks[invoice.invoice_id]
+
         if task.timeout <= 0 or invoice.status == InvoiceStatus.EXPIRED:
             if await self.propagate_event(
                 invoice,

--- a/aiosend/polling/manager.py
+++ b/aiosend/polling/manager.py
@@ -50,7 +50,7 @@ class PollingManager(InvoicePollingManager, CheckPollingManager):
                 stacklevel=2,
             )
         if parallel is not None:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             loop.run_in_executor(None, parallel)
         loggers.polling.info("Start polling")
         await asyncio.gather(


### PR DESCRIPTION
 Went through the codebase to make it safe for free-threaded Python (PEP 703, 3.13t+).

  Main issues I found and fixed:

  - `AiohttpSession` was storing `self._session` on every request call but never actually reading it
  back — just a pointless write to shared state, removed it
  - `_invoice_tasks` and `_check_tasks` are written from sync context (`invoice.poll()` /
  `check.poll()`) but read and deleted from the async polling loop — added `threading.Lock` to protect
  these. Lock is released before any `await` so it doesn't block the event loop
  - `asyncio.get_event_loop()` is deprecated since 3.10 and raises in 3.12+ — switched to
  `get_running_loop()` + `asyncio.run()` in the sync wrapper, and `get_running_loop()` in the polling
  manager
  - iterating `handlers` and `sub_routers` lists without a snapshot could raise `RuntimeError: list
  changed size during iteration` if handlers are registered concurrently — added `list()` snapshot
  before iteration

  Everything still works the same with GIL — the locks just don't get contended. No API changes, no
  architecture changes.