### PR TITLE
Feature/stop polling

### DIFF
--- a/aiosend/client/client.pyi
+++ b/aiosend/client/client.pyi
@@ -229,6 +229,7 @@ class CryptoPay:
         self,
         parallel: Callable[[], Any] | None = None,
     ) -> NoneType: ...
+    def stop_polling(self) -> None: ...
     def get_invoice(
         self,
         invoice: int | Invoice,

--- a/aiosend/polling/base.py
+++ b/aiosend/polling/base.py
@@ -46,6 +46,10 @@ class BasePollingManager(ABC):
     _delay: int
     _kwargs: dict[str, "Any"]
 
+    def _init_polling(self) -> None:
+        """Initialize polling state."""
+        self._stop_event = asyncio.Event()
+
     async def _start_polling(
         self,
         get_updates: "Callable[..., Awaitable[list[Any]]]",
@@ -54,25 +58,34 @@ class BasePollingManager(ABC):
         updater_key: str,
     ) -> None:
         """Start polling."""
-        while True:
-            await asyncio.sleep(self._delay)
-            if not tasks:
-                continue
+        while not self._stop_event.is_set():
             try:
-                updates = await get_updates(**{updater_key: list(tasks)})
-            except Exception:  # noqa: BLE001 logger catches exception
-                loggers.polling.exception("Error while getting updates:\n")
-                continue
-            for update in updates:
+                await asyncio.wait_for(
+                    self._stop_event.wait(),
+                    timeout=self._delay,
+                )
+            except asyncio.TimeoutError:  # noqa: PERF203
+                if not tasks:
+                    continue
                 try:
-                    await handle_update(update)
-                except Exception:  # noqa: BLE001, PERF203
+                    updates = await get_updates(
+                        **{updater_key: list(tasks)},
+                    )
+                except Exception:  # noqa: BLE001
                     loggers.polling.exception(
-                        "Error while handling update:\n",
+                        "Error while getting updates:\n",
                     )
                     continue
-            loggers.polling.debug(
-                "Tasks left: %s Waiting %d seconds...",
-                len(tasks),
-                self._delay,
-            )
+                for update in updates:
+                    try:
+                        await handle_update(update)
+                    except Exception:  # noqa: BLE001, PERF203
+                        loggers.polling.exception(
+                            "Error while handling update:\n",
+                        )
+                        continue
+                loggers.polling.debug(
+                    "Tasks left: %s Waiting %d seconds...",
+                    len(tasks),
+                    self._delay,
+                )

--- a/aiosend/polling/manager.py
+++ b/aiosend/polling/manager.py
@@ -1,4 +1,6 @@
 import asyncio
+import signal
+import sys
 import warnings
 from typing import TYPE_CHECKING
 
@@ -31,6 +33,12 @@ class PollingManager(InvoicePollingManager, CheckPollingManager):
         CheckPollingManager.__init__(self)
         self._timeout = config.timeout
         self._delay = config.delay
+        self._init_polling()
+
+    def stop_polling(self) -> None:
+        """Stop polling."""
+        loggers.polling.info("Stop polling")
+        self._stop_event.set()
 
     async def start_polling(
         self: "ClientWebhookManagerProtocol",
@@ -52,8 +60,16 @@ class PollingManager(InvoicePollingManager, CheckPollingManager):
         if parallel is not None:
             loop = asyncio.get_event_loop()
             loop.run_in_executor(None, parallel)
+        if sys.platform != "win32":
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, self.stop_polling)
         loggers.polling.info("Start polling")
-        await asyncio.gather(
-            self._start_invoice_polling(),
-            self._start_check_polling(),
-        )
+        try:
+            await asyncio.gather(
+                self._start_invoice_polling(),
+                self._start_check_polling(),
+            )
+        except asyncio.CancelledError:
+            self.stop_polling()
+            loggers.polling.info("Polling stopped")

--- a/examples/stop_polling.py
+++ b/examples/stop_polling.py
@@ -9,7 +9,7 @@ cp = CryptoPay("TOKEN")
 @cp.invoice_paid()
 async def payment_handler(invoice: Invoice, payload: str) -> None:
     print("Received", invoice.amount, invoice.asset, payload)
-
+    cp.stop_polling()
 
 async def main() -> None:
     invoice = await cp.create_invoice(1, "USDT")

--- a/examples/stop_polling.py
+++ b/examples/stop_polling.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from aiosend import CryptoPay
+from aiosend.types import Invoice
+
+cp = CryptoPay("TOKEN")
+
+
+@cp.invoice_paid()
+async def payment_handler(invoice: Invoice, payload: str) -> None:
+    print("Received", invoice.amount, invoice.asset, payload)
+
+
+async def main() -> None:
+    invoice = await cp.create_invoice(1, "USDT")
+    print("invoice link:", invoice.bot_invoice_url)
+    invoice.poll(payload="payload")
+    await cp.start_polling()
+
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
# Add `stop_polling()` and graceful SIGINT/SIGTERM handling

Closes #30

## Summary

Adds `stop_polling()` method to `PollingManager` and makes polling stop gracefully on SIGINT (Ctrl+C) and SIGTERM signals.

## Changes

### `aiosend/polling/base.py`

- Added `_init_polling()` method to `BasePollingManager` that creates an `asyncio.Event` for stopping polling.
- Replaced `while True` + `asyncio.sleep()` loop with `asyncio.wait_for(self._stop_event.wait(), timeout)` — this allows the loop to exit **immediately** when `_stop_event` is set, without waiting for the sleep to finish.

### `aiosend/polling/manager.py`

- Added `stop_polling()` method — sets `_stop_event` to stop the polling loop.
- In `start_polling()`, registers signal handlers for `SIGINT` and `SIGTERM` via `loop.add_signal_handler()` on non-Windows platforms.
- Added `except asyncio.CancelledError` handler in `start_polling()` as a fallback.

## How it works

1. **`stop_polling()`** — synchronous method, sets `_stop_event`. Can be called programmatically from handlers:
   ```python
   @cp.invoice_paid()
   async def handler(invoice, payload):
       cp.stop_polling()
   ```

2. **SIGINT / SIGTERM** — `loop.add_signal_handler()` replaces the default signal handler. When a signal arrives, `stop_polling()` is called automatically, the polling loop exits cleanly without `KeyboardInterrupt`.

3. **Windows** — signal handlers are not supported via `loop.add_signal_handler()`, so this is skipped. Users on Windows should call `stop_polling()` manually or catch `KeyboardInterrupt`.
